### PR TITLE
Add TimeComparableID which should be guaranteed non duplicated.

### DIFF
--- a/live_online_test.go
+++ b/live_online_test.go
@@ -56,7 +56,7 @@ func TestLiveDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	live, err := tiktok.TrackUser(test_types.APIKEY)
+	live, err := tiktok.TrackUser(test_types.USERNAME)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestLiveDownload(t *testing.T) {
 	}
 	live.Close()
 
-	live, err = tiktok.TrackUser(test_types.APIKEY)
+	live, err = tiktok.TrackUser(test_types.USERNAME)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types.go
+++ b/types.go
@@ -4,12 +4,18 @@ import "time"
 
 type Event interface {
 	CreatedTimestamp() int64
+	TimeComparableID() int64
 }
 
 type RoomEvent struct {
 	Timestamp int64
+	MessageID int64
 	Type      string
 	Message   string
+}
+
+func (r RoomEvent) TimeComparableID() int64 {
+	return r.MessageID
 }
 
 func (r RoomEvent) CreatedTimestamp() int64 {
@@ -17,9 +23,14 @@ func (r RoomEvent) CreatedTimestamp() int64 {
 }
 
 type ChatEvent struct {
+	MessageID int64
+	Timestamp int64
 	Comment   string
 	User      *User
-	Timestamp int64
+}
+
+func (c ChatEvent) TimeComparableID() int64 {
+	return c.MessageID
 }
 
 func (c ChatEvent) CreatedTimestamp() int64 {
@@ -35,9 +46,14 @@ const (
 )
 
 type UserEvent struct {
+	Timestamp int64
+	MessageID int64
 	Event     userEventType
 	User      *User
-	Timestamp int64
+}
+
+func (u UserEvent) TimeComparableID() int64 {
+	return u.MessageID
 }
 
 func (u UserEvent) CreatedTimestamp() int64 {
@@ -45,8 +61,13 @@ func (u UserEvent) CreatedTimestamp() int64 {
 }
 
 type ViewersEvent struct {
-	Viewers   int
 	Timestamp int64
+	MessageID int64
+	Viewers   int
+}
+
+func (v ViewersEvent) TimeComparableID() int64 {
+	return v.MessageID
 }
 
 func (v ViewersEvent) CreatedTimestamp() int64 {
@@ -54,6 +75,8 @@ func (v ViewersEvent) CreatedTimestamp() int64 {
 }
 
 type GiftEvent struct {
+	MessageID   int64
+	Timestamp   int64
 	ID          int64
 	Name        string
 	Describe    string
@@ -62,8 +85,11 @@ type GiftEvent struct {
 	RepeatEnd   bool
 	Type        int
 	ToUserID    int64
-	Timestamp   int64
 	User        *User
+}
+
+func (g GiftEvent) TimeComparableID() int64 {
+	return g.MessageID
 }
 
 func (g GiftEvent) CreatedTimestamp() int64 {
@@ -71,12 +97,17 @@ func (g GiftEvent) CreatedTimestamp() int64 {
 }
 
 type LikeEvent struct {
+	MessageID   int64
+	Timestamp   int64
 	Likes       int
 	TotalLikes  int
 	User        *User
 	DisplayType string
 	Label       string
-	Timestamp   int64
+}
+
+func (l LikeEvent) TimeComparableID() int64 {
+	return l.MessageID
 }
 
 func (l LikeEvent) CreatedTimestamp() int64 {
@@ -84,9 +115,14 @@ func (l LikeEvent) CreatedTimestamp() int64 {
 }
 
 type QuestionEvent struct {
+	MessageID int64
+	Timestamp int64
 	Quesion   string
 	User      *User
-	Timestamp int64
+}
+
+func (q QuestionEvent) TimeComparableID() int64 {
+	return q.MessageID
 }
 
 func (q QuestionEvent) CreatedTimestamp() int64 {
@@ -94,9 +130,14 @@ func (q QuestionEvent) CreatedTimestamp() int64 {
 }
 
 type ControlEvent struct {
+	MessageID   int64
+	Timestamp   int64
 	Action      int
 	Description string
-	Timestamp   int64
+}
+
+func (c ControlEvent) TimeComparableID() int64 {
+	return c.MessageID
 }
 
 func (c ControlEvent) CreatedTimestamp() int64 {
@@ -104,8 +145,13 @@ func (c ControlEvent) CreatedTimestamp() int64 {
 }
 
 type MicBattleEvent struct {
-	Users     []*User
+	MessageID int64
 	Timestamp int64
+	Users     []*User
+}
+
+func (m MicBattleEvent) TimeComparableID() int64 {
+	return m.MessageID
 }
 
 func (m MicBattleEvent) CreatedTimestamp() int64 {
@@ -113,9 +159,14 @@ func (m MicBattleEvent) CreatedTimestamp() int64 {
 }
 
 type BattlesEvent struct {
+	MessageID int64
+	Timestamp int64
 	Status    int
 	Battles   []*Battle
-	Timestamp int64
+}
+
+func (b BattlesEvent) TimeComparableID() int64 {
+	return b.MessageID
 }
 
 func (b BattlesEvent) CreatedTimestamp() int64 {
@@ -123,8 +174,13 @@ func (b BattlesEvent) CreatedTimestamp() int64 {
 }
 
 type RoomBannerEvent struct {
-	Data      interface{}
+	MessageID int64
 	Timestamp int64
+	Data      interface{}
+}
+
+func (r RoomBannerEvent) TimeComparableID() int64 {
+	return r.MessageID
 }
 
 func (r RoomBannerEvent) CreatedTimestamp() int64 {
@@ -132,10 +188,15 @@ func (r RoomBannerEvent) CreatedTimestamp() int64 {
 }
 
 type IntroEvent struct {
+	MessageID int64
+	Timestamp int64
 	ID        int
 	Title     string
 	User      *User
-	Timestamp int64
+}
+
+func (i IntroEvent) TimeComparableID() int64 {
+	return i.MessageID
 }
 
 func (i IntroEvent) CreatedTimestamp() int64 {
@@ -991,6 +1052,11 @@ type SignedURL struct {
 // should always be emitted.
 type DisconnectEvent struct {
 	created time.Time
+}
+
+func (d DisconnectEvent) TimeComparableID() int64 {
+	// TODO implement me
+	panic("implement me")
 }
 
 func (d DisconnectEvent) CreatedTimestamp() int64 {

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 	switch pt := m.(type) {
 	case *pb.RoomMessage:
 		return RoomEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Type:      pt.Common.Method,
 			Message:   pt.Content,
@@ -50,6 +51,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 				base := base64.RawStdEncoding.EncodeToString(msg.Payload)
 				debugHandler("cannot find proto type for pin message %s:\n%s ", msg.Method, base)
 				return RoomEvent{
+					MessageID: msg.MsgId,
 					Timestamp: pt.Common.CreateTime,
 					Type:      pt.OriginalMsgType,
 					Message:   "<unknown>",
@@ -62,6 +64,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 				debugHandler(err)
 				warnHandler(fmt.Errorf("failed to unmarshal proto %T: %w", m, err))
 				return RoomEvent{
+					MessageID: msg.MsgId,
 					Timestamp: pt.Common.CreateTime,
 					Type:      pt.OriginalMsgType,
 					Message:   "<unknown>",
@@ -74,6 +77,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 			// Todo make a pin return type
 			case *pb.WebcastChatMessage:
 				return ChatEvent{
+					MessageID: pt.Common.MsgId,
 					Timestamp: pt.Common.CreateTime,
 					Comment:   "<pinned>: " + pt2.Content,
 					User:      toUser(pt2.User),
@@ -86,6 +90,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 
 			}
 			return RoomEvent{
+				MessageID: pt.Common.MsgId,
 				Timestamp: pt.Common.CreateTime,
 				Type:      typeStr,
 				Message:   msg,
@@ -93,24 +98,28 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 		}
 	case *pb.WebcastChatMessage:
 		return ChatEvent{
+			MessageID: pt.Common.MsgId,
 			Comment:   pt.Content,
 			User:      toUser(pt.User),
 			Timestamp: pt.Common.CreateTime,
 		}, nil
 	case *pb.WebcastMemberMessage:
 		return UserEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Event:     toUserType(pt.Action.String()),
 			User:      toUser(pt.User),
 		}, nil
 	case *pb.WebcastLiveGameIntroMessage:
 		return RoomEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Type:      pt.Common.Method,
 			Message:   pt.GameText.DefaultPattern,
 		}, nil
 	case *pb.WebcastRoomMessage:
 		return RoomEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Type:      pt.Common.Method,
 			// TODO: Make this actually use pieces list and fill out the format text correctly.
@@ -118,11 +127,13 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 		}, nil
 	case *pb.WebcastRoomUserSeqMessage:
 		return ViewersEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Viewers:   int(pt.Total),
 		}, nil
 	case *pb.WebcastSocialMessage:
 		return UserEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Event:     toUserType(pt.Common.DisplayText.Key),
 			User:      toUser(pt.User),
@@ -133,6 +144,8 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 		}
 
 		return GiftEvent{
+			MessageID:   pt.Common.MsgId,
+			Timestamp:   int64(pt.Common.CreateTime),
 			ID:          int64(pt.GiftId),
 			Name:        pt.Gift.Name,
 			Describe:    pt.Gift.Describe,
@@ -141,11 +154,11 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 			RepeatEnd:   pt.RepeatEnd == 1,
 			Type:        int(pt.Gift.Type),
 			ToUserID:    int64(pt.UserGiftReciever.UserId),
-			Timestamp:   int64(pt.Common.CreateTime),
 			User:        toUser(pt.User),
 		}, nil
 	case *pb.WebcastLikeMessage:
 		return LikeEvent{
+			MessageID:   pt.Common.MsgId,
 			Timestamp:   pt.Common.CreateTime,
 			Likes:       int(pt.Count),
 			TotalLikes:  int(pt.Total),
@@ -156,6 +169,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 
 	case *pb.WebcastQuestionNewMessage:
 		return QuestionEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Quesion:   pt.Details.Text,
 			User:      toUser(pt.Details.User),
@@ -163,6 +177,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 
 	case *pb.WebcastControlMessage:
 		return ControlEvent{
+			MessageID:   pt.Common.MsgId,
 			Timestamp:   pt.Common.CreateTime,
 			Action:      int(pt.Action),
 			Description: pt.Action.String(),
@@ -192,6 +207,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 			}
 		}
 		return MicBattleEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Users:     users,
 		}, nil
@@ -216,14 +232,16 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 			battles = append(battles, battle)
 		}
 		return BattlesEvent{
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
 			Status:    int(pt.BattleStatus),
 			Battles:   battles,
 		}, nil
 	case *pb.WebcastLiveIntroMessage:
 		return IntroEvent{
-			ID:        int(pt.RoomId),
+			MessageID: pt.Common.MsgId,
 			Timestamp: pt.Common.CreateTime,
+			ID:        int(pt.RoomId),
 			Title:     pt.Content,
 			User:      toUser(pt.Host),
 		}, nil
@@ -237,6 +255,7 @@ func parseMsg(msg *pb.WebcastResponse_Message, warnHandler func(...interface{}),
 		}
 
 		return RoomBannerEvent{
+			MessageID: pt.Header.MsgId,
 			Timestamp: pt.Header.CreateTime,
 			Data:      data,
 		}, nil


### PR DESCRIPTION
Unlike the timestamp, should be ordered and unique, which means should only need a single variable to prevent redundant messages.